### PR TITLE
Start saftd and dbus-daemon with realtime priority

### DIFF
--- a/scripts/deployment/RTE_Timing/timing-rte.sh
+++ b/scripts/deployment/RTE_Timing/timing-rte.sh
@@ -63,6 +63,6 @@ echo 'dbus:*:100:' >> /etc/group
 mkdir /var/run/dbus
 
 log 'starting services'
-dbus-daemon --system
-saftd baseboard:dev/wbm0 >/tmp/saftd.log 2>&1 &
+chrt -r 25 dbus-daemon --system
+chrt -r 30 saftd baseboard:dev/wbm0 >/tmp/saftd.log 2>&1 &
 dbus-uuidgen > /etc/machine-id


### PR DESCRIPTION
Start saftd and dbus-daemon with round-robin realtime scheduling. Priority 25 is above any FESA thread. This should help with delays in the interrupt handler at high CPU load.